### PR TITLE
Fix data/null component bug upon substitution of framework component

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,10 +1,15 @@
 .. default-role:: obj
 
-..
-   latest
-   ------
 
-   Yet to be versioned and released. Only available from *dev* branch until then.
+latest
+------
+
+Yet to be versioned and released. Only available from *dev* branch until then.
+
+* fix `DataComponent`/`NullComponent` bug making them unusable as
+  substitute components in a `Model`
+  (`#87 <https://github.com/unifhy-org/unifhy/issues/87>`_)
+
 
 v0.1.1
 ------

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -63,6 +63,7 @@ if __name__ == '__main__':
     test_suite.addTests(doctest.DocTestSuite(unifhy.data))
     test_suite.addTests(doctest.DocTestSuite(unifhy.time))
     test_suite.addTests(doctest.DocTestSuite(unifhy.space))
+    test_suite.addTests(doctest.DocTestSuite(unifhy.component))
     test_suite.addTests(doctest.DocTestSuite(unifhy.model))
     test_suite.addTests(doctest.DocTestSuite(unifhy._utils.clock))
     test_suite.addTests(doctest.DocTestSuite(unifhy._utils.exchanger))

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -3,16 +3,25 @@ import doctest
 
 import unifhy
 from tests.test_model import (
-    TestModelSameTimeSameSpace, TestModelSameTimeDiffSpace,
-    TestModelDiffTimeSameSpace, TestModelDiffTimeDiffSpace
+    TestModelSameTimeSameSpace,
+    TestModelSameTimeDiffSpace,
+    TestModelDiffTimeSameSpace,
+    TestModelDiffTimeDiffSpace
 )
 from tests.test_space import (
-    TestLatLonGridAPI, TestGridComparison
+    TestLatLonGridAPI,
+    TestGridComparison
 )
 from tests.test_time import (
-    TestTimeDomainAPI, TestTimeDomainComparison
+    TestTimeDomainAPI,
+    TestTimeDomainComparison
 )
-from tests.test_utils.test_clock import TestClock
+from tests.test_utils.test_clock import (
+    TestClock
+)
+from tests.test_component import (
+    TestSubstituteComponent
+)
 
 
 if __name__ == '__main__':
@@ -46,6 +55,9 @@ if __name__ == '__main__':
     )
     test_suite.addTests(
         test_loader.loadTestsFromTestCase(TestClock)
+    )
+    test_suite.addTests(
+        test_loader.loadTestsFromTestCase(TestSubstituteComponent)
     )
 
     test_suite.addTests(doctest.DocTestSuite(unifhy.data))

--- a/tests/run_basic_tests.py
+++ b/tests/run_basic_tests.py
@@ -1,14 +1,23 @@
 import unittest
 import doctest
 
-from tests.test_model import BasicTestModel
+from tests.test_model import (
+    BasicTestModel
+)
 from tests.test_space import (
-    TestLatLonGridAPI, TestGridComparison
+    TestLatLonGridAPI,
+    TestGridComparison
 )
 from tests.test_time import (
-    TestTimeDomainAPI, TestTimeDomainComparison
+    TestTimeDomainAPI,
+    TestTimeDomainComparison
 )
-from tests.test_utils.test_clock import TestClock
+from tests.test_utils.test_clock import (
+    TestClock
+)
+from tests.test_component import (
+    TestSubstituteComponent
+)
 import unifhy
 
 
@@ -51,6 +60,9 @@ if __name__ == '__main__':
     )
     test_suite.addTests(
         test_loader.loadTestsFromTestCase(TestClock)
+    )
+    test_suite.addTests(
+        test_loader.loadTestsFromTestCase(TestSubstituteComponent)
     )
 
     test_suite.addTests(doctest.DocTestSuite(unifhy.data))

--- a/tests/run_basic_tests.py
+++ b/tests/run_basic_tests.py
@@ -68,6 +68,7 @@ if __name__ == '__main__':
     test_suite.addTests(doctest.DocTestSuite(unifhy.data))
     test_suite.addTests(doctest.DocTestSuite(unifhy.time))
     test_suite.addTests(doctest.DocTestSuite(unifhy.space))
+    test_suite.addTests(doctest.DocTestSuite(unifhy.component))
     test_suite.addTests(doctest.DocTestSuite(unifhy.model))
     test_suite.addTests(doctest.DocTestSuite(unifhy._utils.clock))
     test_suite.addTests(doctest.DocTestSuite(unifhy._utils.exchanger))

--- a/tests/tests/test_component.py
+++ b/tests/tests/test_component.py
@@ -1,4 +1,5 @@
 import unittest
+import doctest
 from importlib import import_module
 from datetime import timedelta
 import numpy
@@ -276,6 +277,8 @@ if __name__ == '__main__':
     test_suite.addTests(
         test_loader.loadTestsFromTestCase(TestSubstituteComponent)
     )
+
+    test_suite.addTests(doctest.DocTestSuite(unifhy.component))
 
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(test_suite)

--- a/unifhy/component.py
+++ b/unifhy/component.py
@@ -127,6 +127,34 @@ class MetaComponent(abc.ABCMeta):
         return cls._requires_cell_area
 
     def __str__(cls):
+        """**Examples:**
+
+        >>> from tests.components.surfacelayer import Dummy
+        >>> print(Dummy)
+        Dummy(
+            category: surfacelayer
+            inwards metadata:
+                transfer_k [1]
+                transfer_l [1]
+                transfer_n [1]
+            inputs metadata:
+                driving_a [1]
+                driving_b [1]
+                driving_c [1]
+                ancillary_c [1]
+            requires land sea mask: True
+            requires flow direction: True
+            requires cell area: False
+            states metadata:
+                state_a [1]
+                state_b [1]
+            outwards metadata:
+                transfer_i [1]
+                transfer_j [1]
+            outputs metadata:
+                output_x [1]
+        )
+        """
         info_a = [
             "\n".join(
                 ([f"    {t.replace('_info', ' metadata').replace('_', '')}:"]

--- a/unifhy/component.py
+++ b/unifhy/component.py
@@ -25,27 +25,32 @@ from .settings import dtype_float, array_order
 
 class MetaComponent(abc.ABCMeta):
     """MetaComponent is a metaclass for `Component`."""
-    # intrinsic attributes
-    _category = None
+    def __new__(mcs, *args, **kwargs):
+        class_ = super().__new__(mcs, *args, **kwargs)
 
-    _inwards_info = None
-    _outwards_info = None
+        # intrinsic attributes
+        mcs._category = None
 
-    _inwards = None
-    _outwards = None
+        mcs._inwards_info = None
+        mcs._outwards_info = None
 
-    # definition attributes
-    _inputs_info = None
-    _parameters_info = None
-    _constants_info = None
-    _states_info = None
-    _outputs_info = None
+        mcs._inwards = None
+        mcs._outwards = None
 
-    _solver_history = None
+        # definition attributes
+        mcs._inputs_info = None
+        mcs._parameters_info = None
+        mcs._constants_info = None
+        mcs._states_info = None
+        mcs._outputs_info = None
 
-    _requires_land_sea_mask = None
-    _requires_flow_direction = None
-    _requires_cell_area = None
+        mcs._solver_history = None
+
+        mcs._requires_land_sea_mask = None
+        mcs._requires_flow_direction = None
+        mcs._requires_cell_area = None
+
+        return class_
 
     @property
     def category(cls):

--- a/unifhy/component.py
+++ b/unifhy/component.py
@@ -1407,6 +1407,10 @@ class SurfaceLayerComponent(Component, metaclass=abc.ABCMeta):
             'method': 'mean'
         }
     }
+    # if not specified, assume all inwards are required
+    _inwards = tuple(_inwards_info)
+    # if not specified, assume all outwards are produced
+    _outwards = tuple(_outwards_info)
 
 
 class SubSurfaceComponent(Component, metaclass=abc.ABCMeta):
@@ -1478,6 +1482,10 @@ class SubSurfaceComponent(Component, metaclass=abc.ABCMeta):
             'method': 'mean'
         }
     }
+    # if not specified, assume all inwards are required
+    _inwards = tuple(_inwards_info)
+    # if not specified, assume all outwards are produced
+    _outwards = tuple(_outwards_info)
 
 
 class OpenWaterComponent(Component, metaclass=abc.ABCMeta):
@@ -1519,6 +1527,10 @@ class OpenWaterComponent(Component, metaclass=abc.ABCMeta):
             'method': 'mean'
         }
     }
+    # if not specified, assume all inwards are required
+    _inwards = tuple(_inwards_info)
+    # if not specified, assume all outwards are produced
+    _outwards = tuple(_outwards_info)
 
 
 class DataComponent(Component):

--- a/unifhy/component.py
+++ b/unifhy/component.py
@@ -25,32 +25,27 @@ from .settings import dtype_float, array_order
 
 class MetaComponent(abc.ABCMeta):
     """MetaComponent is a metaclass for `Component`."""
-    def __new__(mcs, *args, **kwargs):
-        class_ = super().__new__(mcs, *args, **kwargs)
+    # intrinsic attributes
+    _category = None
 
-        # intrinsic attributes
-        mcs._category = None
+    _inwards_info = None
+    _outwards_info = None
 
-        mcs._inwards_info = None
-        mcs._outwards_info = None
+    _inwards = None
+    _outwards = None
 
-        mcs._inwards = None
-        mcs._outwards = None
+    # definition attributes
+    _inputs_info = None
+    _parameters_info = None
+    _constants_info = None
+    _states_info = None
+    _outputs_info = None
 
-        # definition attributes
-        mcs._inputs_info = None
-        mcs._parameters_info = None
-        mcs._constants_info = None
-        mcs._states_info = None
-        mcs._outputs_info = None
+    _solver_history = None
 
-        mcs._solver_history = None
-
-        mcs._requires_land_sea_mask = None
-        mcs._requires_flow_direction = None
-        mcs._requires_cell_area = None
-
-        return class_
+    _requires_land_sea_mask = None
+    _requires_flow_direction = None
+    _requires_cell_area = None
 
     @property
     def category(cls):


### PR DESCRIPTION
resolve #87 

This PR:
- fixes data/null component bug by assigning default values for the `_inwards` and `_outwards` class attributes of the framework components `SurfaceLayerComponent`/`SubSurfaceComponent`/`OpenWaterComponent` (default value being the list of keys of their respective `_inwards_info` and `_outwards_info` class attributes, i.e. assuming that the whole set of inward/outward transfers is used/produced.
- adds unit test to check the new behaviour above when instantiating data/null component
- adds doc test in MetaComponent to check for the correct component metaclass display (through printing the component class itself)